### PR TITLE
Fix bridge address for IPv6 networks

### DIFF
--- a/libhue/discovery.cpp
+++ b/libhue/discovery.cpp
@@ -86,6 +86,7 @@ void Discovery::onReadyRead()
 
 //        qDebug() << "got datagram" << datagram;
         if (!m_reportedBridges.contains(sender)) {
+            sender.setAddress(sender.toIPv4Address());
             m_reportedBridges << sender;
             emit foundBridge(sender);
         }


### PR DESCRIPTION
The connection to the bridge does not work in an IPv6 network. In my case, the toString() method from the sender returned "::ffff:192.168.0.14" which is not applicable for the bridge URL.